### PR TITLE
Update commons-collections from 3.2.1 to 3.2.2

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -51,7 +51,7 @@
 		<atomikos.version>3.9.3</atomikos.version>
 		<bitronix.version>2.1.4</bitronix.version>
 		<commons-beanutils.version>1.9.2</commons-beanutils.version>
-		<commons-collections.version>3.2.1</commons-collections.version>
+		<commons-collections.version>3.2.2</commons-collections.version>
 		<commons-dbcp.version>1.4</commons-dbcp.version>
 		<commons-dbcp2.version>2.0.1</commons-dbcp2.version>
 		<commons-digester.version>2.1</commons-digester.version>


### PR DESCRIPTION
Update commons-collections from 3.2.1 to 3.2.2 to fix "Mad Gadget vulnerability"

https://blogs.apache.org/foundation/entry/apache_commons_statement_to_widespread